### PR TITLE
Changed hardcoded reference to /tmp for sys_get_temp_dir()

### DIFF
--- a/OpenVBX/libraries/twilio.php
+++ b/OpenVBX/libraries/twilio.php
@@ -155,7 +155,7 @@
 					// curl_setopt($curl, CURLOPT_PUT, TRUE);
 					curl_setopt($curl, CURLOPT_POSTFIELDS, $encoded);
 					curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
-					file_put_contents($tmpfile = tempnam("/tmp", "put_"),
+					file_put_contents($tmpfile = tempnam(realpath(sys_get_temp_dir())), "put_"),
 						$encoded);
 					curl_setopt($curl, CURLOPT_INFILE, $fp = fopen($tmpfile,
 						'r'));


### PR DESCRIPTION
After a few hours of struggling with a relocated openVBX installation, I finally found out why it wasn't working well. Turns out there's a hardcoded reference to /tmp that will most likely break if the server where the script is running has either open_basedir or safe_mode enabled.

This fix worked for me.
