### PR TITLE
Config changes for sessions name and server_name/http_host

### DIFF
--- a/OpenVBX/config/config.php
+++ b/OpenVBX/config/config.php
@@ -324,7 +324,7 @@ $config['encryption_key'] = "";
 | 'time_to_update'		= how many seconds between CI refreshing Session Information
 |
 */
-$config['sess_cookie_name']		= 'openvbxsession';
+$config['sess_cookie_name']		= 'openvbx_session';
 $config['sess_expiration']		= 7200;
 $config['sess_encrypt_cookie']	= FALSE;
 $config['sess_use_database']	= FALSE;


### PR DESCRIPTION
Need to check codebase for other $_SERVER['server_name'] uses.  One is in MY_config.php (https://github.com/twilio/OpenVBX/blob/master/OpenVBX/libraries/MY_Config.php#L70) and the other is in builtin email library (https://github.com/twilio/OpenVBX/blob/master/system/libraries/Email.php#L1841)
