### PR TITLE
Fix to use recording_host in voicemail email notifications

### DIFF
--- a/OpenVBX/models/vbx_message.php
+++ b/OpenVBX/models/vbx_message.php
@@ -396,7 +396,7 @@ class VBX_Message extends Model {
 		$recording_host = $ci->settings->get('recording_host', VBX_PARENT_TENANT);
 		
 		$vm_url = $message->content_url;
-		if (trim($recording_host) != '') {git 
+		if (trim($recording_host) != '') { 
 			$vm_url = str_replace('api.twilio.com',trim($recording_host), $vm_url);
 		}
 		$message->content_url = $vm_url;


### PR DESCRIPTION
Small change to /OpenVBX/models/vbx_message.php to use recording_host specified under "settings" and use it in the voicemail email notifications if it was specified.
