### PR TITLE
Fix for Issue #198 

### DIFF
--- a/OpenVBX/libraries/OpenVBX.php
+++ b/OpenVBX/libraries/OpenVBX.php
@@ -451,6 +451,7 @@ class OpenVBX {
 		{
 			// we weren't handed post-vars, use the default
 			$post_vars = $_POST;
+			if(empty($post_vars) && !empty($_SERVER['QUERY_STRING'])) $url .= '?'.$_SERVER['QUERY_STRING'];
 		}
 
 		return self::$_twilioValidator->validate(self::getRequestSignature(), $url, $post_vars);


### PR DESCRIPTION
This solves an issue where a Location header is used to redirect Twilio to OpenVBX and the Twilio proxy uses a GET request instead of a POST. Added a check that sees if a query string is present and $post_vars is empty, then update the URL to use the query string. The validation then works.
