### PR TITLE
timing plugin always says "closed" on Sundays

### DIFF
--- a/plugins/timing/applets/timing/twiml.php
+++ b/plugins/timing/applets/timing/twiml.php
@@ -1,8 +1,12 @@
 <?php
 $response = new TwimlResponse;
 
+function modwrap($num, $mod) {
+    return ($mod + ($num % $mod)) % $mod;
+}
+
 $now = date_create('now');
-$today = date_format($now, 'w') - 1;
+$today = modwrap(date_format($now, 'w') - 1, 7);
 
 $response->redirect(AppletInstance::getDropZoneUrl(
   ($from = AppletInstance::getValue("range_{$today}_from"))


### PR DESCRIPTION
There is a bug in the timing plugin that causes it to always return the "closed" path on Sundays, regardless of the time. This is because the calculation of the index into the array of weekdays goes to -1 on Sundays. The patch fixes this by correctly wrapping the index around, modulus-style.
