### PR TITLE
Fixes device edit, display, and save in regards to sequencing

### DIFF
--- a/OpenVBX/models/vbx_device.php
+++ b/OpenVBX/models/vbx_device.php
@@ -62,7 +62,7 @@ class VBX_Device extends MY_Model
 		$sql_options = array(
 			'joins' => self::$joins,
 			'select' => self::$select,
-			'order_by' => array('sequence', 'desc'),
+			'order_by' => array('sequence', 'asc'),
 		);
 		$device = new self();
 		
@@ -100,6 +100,7 @@ class VBX_Device extends MY_Model
 			'value' => normalize_phone_to_E164($number['value']),
 			'user_id' => intval($number['user_id']),
 			'sms' => $number['sms'],
+			'sequence' => $number['sequence'],
 			'tenant_id' => $ci->tenant->id
 		));
 
@@ -132,7 +133,7 @@ class VBX_Device extends MY_Model
 			'user_id' => intval($user_id)
 		);
 		$sql_opts = array(
-			'order_by' => array('sequence', 'desc')	
+			'order_by' => array('sequence', 'asc')
 		);
 		$devices = parent::search(
 			self::$__CLASS__,

--- a/assets/j/devices.js
+++ b/assets/j/devices.js
@@ -44,6 +44,12 @@ $(document).ready(function() {
 				var ajaxUrl = OpenVBX.home + '/devices/number/add';
 				var params = $('#dialog-number').values();
 
+				if($('.device-list').css('display')=='none') {
+					params['number[sequence]'] = 0;
+				} else {
+					params['number[sequence]'] = $('.device-list').length;
+				}
+
 				$.post(ajaxUrl, params, function(data) {
 
 					$('#dialog-number .error-message').text(data.message).removeClass('hide');


### PR DESCRIPTION
This is a clean commit that fixes issue reported in: twilio/OpenVBX#224

Fixed device order return in model for search, get_by_user.
Added 'sequence' to add function where it specifies fields to save.
Also fixed devices.js to send sequence based on device list presence and state.

I'm not sure what VBX_Device::get_by_group is used for, but those SQL options will probably need to change too, at line 117. I can fix this if someone can point me towards a use-case. But...I couldn't find VBX_Device::get_by_group in use in core.
