### PR TITLE
Sunday fix

### DIFF
--- a/plugins/timing/applets/timing/twiml.php
+++ b/plugins/timing/applets/timing/twiml.php
@@ -2,7 +2,7 @@
 $response = new TwimlResponse;
 
 $now = date_create('now');
-$today = date_format($now, 'w') - 1;
+$today = date_format($now, 'N') - 1;
 
 /** 
  * The names of the applet instance variables for "from" and "to" times 


### PR DESCRIPTION
Guess very few people have used the timing plugin for open on Sunday. Wrong date format made Sunday always closed. Simple one character fix.

Not sure if this will cleanly apply, as I had an old fork of the repo with some custom changes that were never merged. 
