### PR TITLE
fixed error for "Can't use method return value in write context"

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -1839,7 +1839,7 @@ class CI_Email {
 	function _get_hostname()
 	{
 		$CI =& get_instance();
-		return (!empty($CI->config->item('server_name'))) ? $CI->config->item('server_name') : 'localhost.localdomain';
+		return $CI->config->item('server_name') ? $CI->config->item('server_name') : 'localhost.localdomain';
 	}
   
 	// --------------------------------------------------------------------


### PR DESCRIPTION
Without this change PHP throws an error:

> Can't use method return value in write context

For notes on why the `empty()` function is not necessary see http://stackoverflow.com/questions/1075534/cant-use-method-return-value-in-write-context
