### PR TITLE
Replaces deprecated PHP function preg_replace with preg_replace_callback

### DIFF
--- a/OpenVBX/libraries/Services/Twilio/Resource.php
+++ b/OpenVBX/libraries/Services/Twilio/Resource.php
@@ -87,7 +87,7 @@ abstract class Services_Twilio_Resource {
      * @return string
      */
     public static function camelize($word) {
-        return preg_replace('/(^|_)([a-z])/e', 'strtoupper("\\2")', $word);
+        return preg_replace_callback('/(^|_)([a-z])/e', 'strtoupper("\\2")', $word);
     }
 
     /**


### PR DESCRIPTION
preg_replace function is now deprecated, this has been replaced with preg_replace_callback function.
