### PR TITLE
Send calls to voicemail if line is busy

### DIFF
--- a/plugins/standard/applets/dial/TwimlDial.php
+++ b/plugins/standard/applets/dial/TwimlDial.php
@@ -14,7 +14,7 @@ class TwimlDial {
 	private $use_ci_session = true;
 	
 	static $hangup_stati = array('completed', 'answered');
-	static $voicemail_stati = array('no-answer', 'failed');
+	static $voicemail_stati = array('no-answer', 'failed', 'busy');
 	static $default_voicemail_message = 'Please leave a message. Press the pound key when you are finished.';
 	
 	protected $cookie_name;


### PR DESCRIPTION
The dial applet silently fails if the number called is busy. This makes it treat it as a no-answer.
