### PR TITLE
Conference Call Applet: New Feature - Record Call Option

### DIFF
--- a/plugins/standard/applets/conference/twiml.php
+++ b/plugins/standard/applets/conference/twiml.php
@@ -8,6 +8,7 @@ $caller = normalize_phone_to_E164(isset($_REQUEST['From'])? $ci->input->get_post
 $isModerator = false;
 $defaultWaitUrl = 'http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient';
 $waitUrl = AppletInstance::getValue('wait-url', $defaultWaitUrl);
+$record = AppletInstance::getValue('record','do-not-record');
 
 $hasModerator = false;
 
@@ -45,6 +46,7 @@ $confOptions = array(
 	'startConferenceOnEnter' => (!$hasModerator || $isModerator)? 'true' : 'false',
 	'endConferenceOnExit' => ($hasModerator && $isModerator)? 'true' : 'false',
 	'waitUrl' => $waitUrl,
+	'record' => $record,
 );
 
 $response = new TwimlResponse();

--- a/plugins/standard/applets/conference/ui.php
+++ b/plugins/standard/applets/conference/ui.php
@@ -15,6 +15,7 @@ $musicOptions = array(
 					  array("url" => "http://twimlets.com/holdmusic?Bucket=com.twilio.music.soft-rock",
 							"name" => "Soft Rock"),
 					  );
+$record = AppletInstance::getValue('record','do-not-record');
 ?>
 <div class="vbx-applet">
 		<h2>Moderator</h2>
@@ -33,6 +34,28 @@ $musicOptions = array(
 			<input type="hidden" name="conf-id" value="<?php echo AppletInstance::getValue('conf-id', 'conf_'.mt_rand()) ?>" />
 		</fieldset>
 		</div><!-- .vbx-full-pane -->
+		
+		<h2>Call Recording</h2>
+		<div class="radio-table">
+			<table>
+				<tr class="radio-table-row first <?php echo ($record === 'record-from-start') ? 'on' : 'off' ?>">
+					<td class="radio-cell">
+						<input type="radio" class='dial-whom-selector-radio' name="record" value="record-from-start" <?php echo ($record === 'record-from-start') ? 'checked="checked"' : '' ?> />
+					</td>
+					<td class="content-cell">
+						<h4>Enable</h4>
+					</td>
+				</tr>
+				<tr class="radio-table-row last <?php echo ($record === 'do-not-record') ? 'on' : 'off' ?>">
+					<td class="radio-cell">
+						<input type="radio" class='dial-whom-selector-radio' name="record" value="do-not-record" <?php echo ($record === 'do-not-record') ? 'checked="checked"' : '' ?> />
+					</td>
+					<td class="content-cell">
+						<h4>Disable</h4>
+					</td>
+				</tr>
+			</table>
+		</div>
 
 </div><!-- .vbx-applet -->
 


### PR DESCRIPTION
The conference call applet now has the ability to optionally record a call when setting up the flow.

The default value is set to disable or "do-not-record".

![conference-call-recording](https://cloud.githubusercontent.com/assets/4819310/10327504/0b8c5bc0-6c76-11e5-828b-586d6319d3e1.PNG)