### PR TITLE
Conference Call - List Calls, Join and Listen

### DIFF
--- a/OpenVBX/controllers/twiml.php
+++ b/OpenVBX/controllers/twiml.php
@@ -320,6 +320,7 @@ class Twiml extends MY_Controller {
 
 		$rest_access = $this->input->get_post('rest_access');
 		$to = $this->input->get_post('to');
+		$conference_name = $this->input->get_post('conference_name');
 		$callerid = $this->input->get_post('callerid');
 
 		if(!$this->session->userdata('loggedin')
@@ -360,8 +361,11 @@ class Twiml extends MY_Controller {
 			{
 				$this->dial_user_by_client_id($this->input->get_post('to'), $options);
 			}
-			else 
+			elseif(strlen($conference_name) > 0)
 			{
+				$this->join_conference($conference_name, $this->input->get_post('muted'), $this->input->get_post('beep'));
+			}
+			else			{
 				$to = normalize_phone_to_E164($to);
 				$this->response->dial($to, $options);
 			}
@@ -396,7 +400,35 @@ class Twiml extends MY_Controller {
 		}
 		else
 		{
-			$this->reponse->say('Unknown client id: '.$user_id.'. Goodbye.');
+			$this->response->say('Unknown client id: '.$user_id.'. Goodbye.');
+			$this->response->hangup();
+		}
+	}
+	
+	/**
+	 * Join A Conference Call
+	 *
+	 * @param string $conference_name 
+	 * @param string $muted
+	 * @param string $beep
+	 * @return void
+	 */
+	protected function join_conference($conference_name,$muted,$beep)
+	{
+		if (strlen($conference_name)>2)
+		{
+			$confOptions = array(
+				'muted' => $muted,
+				'beep' => $beep,
+				'startConferenceOnEnter' => 'false'
+			);
+			
+			$dial = $this->response->dial(NULL, NULL);
+			$dial->conference($conference_name, $confOptions);
+		}
+		else
+		{
+			$this->response->say('Invalid confernce call name. Goodbye.');
 			$this->response->hangup();
 		}
 	}

--- a/plugins/standard/applets/conference/conference-calls.php
+++ b/plugins/standard/applets/conference/conference-calls.php
@@ -1,0 +1,97 @@
+<?php
+
+if(isset($_GET['json'])):
+
+	$ci =& get_instance();
+
+	$service = new Services_Twilio($ci->twilio_sid, $ci->twilio_token);
+
+	$conferences = $service->account->conferences->getIterator(0, 50, array("Status" => "in-progress"));
+
+	$res = array();
+	
+	foreach($conferences as $call) {
+		$res[$call->friendly_name] = array(
+			'date_created' => date("F j, Y, g:i a",strtotime($call->date_created)),
+			'friendly_name' => $call->friendly_name,
+			'status' => $call->status,
+			'duration' => $call->duration
+		);		
+	}
+	
+	die(json_encode($res));
+	
+endif;
+
+?>
+
+<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.2.6/jquery.min.js"></script>
+<script>
+
+	function join_call(conference_name){
+		
+		window.parent.Client.call({ 
+			'conference_name' : conference_name,
+			'muted' : 'false',
+			'beep' : 'true',
+			'Digits' : 1});
+		
+		return false;
+	}
+	
+	function listen_call(conference_name){
+
+		window.parent.Client.call({ 
+			'conference_name' : conference_name,
+			'muted' : 'true',
+			'beep' : 'false',
+			'Digits' : 1});
+		
+		return false;
+	}
+	
+	var $ = jQuery;
+		
+	$(function(){
+				
+		var
+		calls = {},
+		select = $('#calls'),
+		updateCalls = function() {
+			$.getJSON(window.location + '/?json=1', function(data) {
+				$.each(data, function(conference_name, call) {
+					if(!calls[conference_name]) {
+						calls[conference_name] = call;
+						select.append('<tr class="message-row recording-type" id="' + call.friendly_name + '"><td class="recording-date">' + call.date_created + '</td><td class="recording-duration">' + call.friendly_name + '</td><td class="recording-duration">' + call.status + '</td><td class="recording-duration" ><a id="join" onclick="join_call(\'' + call.friendly_name + '\');">Join</a></td><td class="recording-duration" ><a id="listen" onclick="listen_call(\'' + call.friendly_name + '\');">Listen</a></td></tr>');
+					}
+				});
+		
+				$.each(calls, function(conference_name, call) {
+				  if(!data[conference_name]) {
+					delete calls[conference_name];
+					$('#' + conference_name).fadeOut(250, function() {
+					  $(this).remove();
+					});
+				  }
+				});
+			});
+		};
+
+		updateCalls();
+		setInterval(updateCalls, 5000);
+	});
+</script>
+
+<div class="vbx-content-main">
+	<div class="vbx-content-menu vbx-content-menu-top">
+		<h2 class="vbx-content-heading">Conference Calls In Progress</h2>
+	</div><!-- .vbx-content-menu -->
+		<div class="vbx-content-container">
+		<div class="vbx-content-section">
+			<table class="vbx-items-grid" border="0" id="calls">
+				<tr class="items-head recording-head"><th>Start Time</th><th>Conference Name</th><th>Status</th><th>Join</th><th>Listen</th></tr>
+
+			</table>
+		</div><!-- .vbx-content-section -->
+	</div><!-- .vbx-content-container -->
+</div><!-- .vbx-content-main -->

--- a/plugins/standard/applets/conference/twiml.php
+++ b/plugins/standard/applets/conference/twiml.php
@@ -8,6 +8,7 @@ $caller = normalize_phone_to_E164(isset($_REQUEST['From'])? $ci->input->get_post
 $isModerator = false;
 $defaultWaitUrl = 'http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient';
 $waitUrl = AppletInstance::getValue('wait-url', $defaultWaitUrl);
+$record = AppletInstance::getValue('record','do-not-record');
 
 $hasModerator = false;
 
@@ -45,6 +46,7 @@ $confOptions = array(
 	'startConferenceOnEnter' => (!$hasModerator || $isModerator)? 'true' : 'false',
 	'endConferenceOnExit' => ($hasModerator && $isModerator)? 'true' : 'false',
 	'waitUrl' => $waitUrl,
+	'record' => $record,
 );
 
 $response = new TwimlResponse();

--- a/plugins/standard/applets/conference/ui.php
+++ b/plugins/standard/applets/conference/ui.php
@@ -15,6 +15,7 @@ $musicOptions = array(
 					  array("url" => "http://twimlets.com/holdmusic?Bucket=com.twilio.music.soft-rock",
 							"name" => "Soft Rock"),
 					  );
+$record = AppletInstance::getValue('record','do-not-record');
 ?>
 <div class="vbx-applet">
 		<h2>Moderator</h2>
@@ -33,6 +34,28 @@ $musicOptions = array(
 			<input type="hidden" name="conf-id" value="<?php echo AppletInstance::getValue('conf-id', 'conf_'.mt_rand()) ?>" />
 		</fieldset>
 		</div><!-- .vbx-full-pane -->
+		
+		<h2>Call Recording</h2>
+		<div class="radio-table">
+			<table>
+				<tr class="radio-table-row first <?php echo ($record === 'record-from-start') ? 'on' : 'off' ?>">
+					<td class="radio-cell">
+						<input type="radio" class='dial-whom-selector-radio' name="record" value="record-from-start" <?php echo ($record === 'record-from-start') ? 'checked="checked"' : '' ?> />
+					</td>
+					<td class="content-cell">
+						<h4>Enable</h4>
+					</td>
+				</tr>
+				<tr class="radio-table-row last <?php echo ($record === 'do-not-record') ? 'on' : 'off' ?>">
+					<td class="radio-cell">
+						<input type="radio" class='dial-whom-selector-radio' name="record" value="do-not-record" <?php echo ($record === 'do-not-record') ? 'checked="checked"' : '' ?> />
+					</td>
+					<td class="content-cell">
+						<h4>Disable</h4>
+					</td>
+				</tr>
+			</table>
+		</div>
 
 </div><!-- .vbx-applet -->
 

--- a/plugins/standard/plugin.json
+++ b/plugins/standard/plugin.json
@@ -2,5 +2,11 @@
     "name" : "Standard",
     "author" : "Twilio <vbx@twilio.com>",
     "description" : "Standard set of applets for OpenVBX",
-    "url" : "http://openvbx.org"
+    "url" : "http://openvbx.org",
+	"links" : [{
+					"menu" : "Call Log",
+					"url" : "applets/conference/conference-calls",
+					"script" : "applets/conference/conference-calls.php",
+					"label" : "Conference Calls"
+			}]
 }


### PR DESCRIPTION
This new features gives the standard conference call plugin a new menu under the "Call Log" section which allows a user to see a list of all conference calls in-progress and gives the option to join or listen to the call.  When the user clicks Join the browser client immediately connects them to the call, announces their entrance and exit with a beep and allows them to listen and speak.  When the user chooses the Listen option their browser client immediately connects them to the call but does not announce their entry or exit and only allows the user to listen to the call.


![conference-join-listen](https://cloud.githubusercontent.com/assets/4819310/10413840/bc3e483e-6f87-11e5-9044-6c7bca5c0f5d.PNG)