### PR TITLE
User Management: Enable/Disable Admin Rights

### DIFF
--- a/OpenVBX/controllers/account.php
+++ b/OpenVBX/controllers/account.php
@@ -35,6 +35,7 @@ class Account extends User_Controller {
 	private $editable_fields = array('first_name',
 									 'last_name',
 									 'email',
+									 'is_admin',
 									 'pin',
 									 'notification');
 	protected $user_id;
@@ -140,9 +141,16 @@ class Account extends User_Controller {
 			$val = $this->input->post($field);
 			if (in_array($field, $user->admin_fields))
 			{
-				if (($val || $val === '0') && $is_admin)
+				if($user->id != $this->session->userdata('user_id') && $is_admin)
 				{
-					$user->$field = $val;
+					if (($val || $val === '0'))
+					{
+						$user->$field = $val;
+					}
+					else
+					{
+						$user->$field = '0';
+					}
 				}
 			}
 			else

--- a/OpenVBX/models/vbx_user.php
+++ b/OpenVBX/models/vbx_user.php
@@ -50,7 +50,7 @@ class VBX_User extends MY_Model {
 						'tenant_id',
 					);
 
-	public $admin_fields = array('');
+	public $admin_fields = array('is_admin');
 	
 	public $devices;
 	

--- a/OpenVBX/views/account.php
+++ b/OpenVBX/views/account.php
@@ -38,6 +38,17 @@
 				<label class="field-label">E-Mail Address
 					<input type="text" class="medium" name="email" value="<?php echo $user->email; ?>" />
 				</label>
+				<?php if ($current_user->is_admin && $user->id != $current_user->id): ?>
+				<label class="field-label">Is Administrator
+					<?php
+					$params = array(
+						'name' => 'is_admin',
+						'id' => 'is_admin'
+					);
+					echo form_checkbox($params, '1', ($user->is_admin == 1));
+				?>
+				</label>
+				<?php endif; ?>
 			</fieldset>
 				
 			<button type="submit" class="inline-button submit-button"><span>Save</span></button>


### PR DESCRIPTION
Administrators now have the ability to enable and disable admin rights for other users.  Admin user cannot change their own priviledges in order to prevent them from disabling admin rights for their own user that might be the only user with admin rights


![user-rights](https://cloud.githubusercontent.com/assets/4819310/10504821/797c439e-72d3-11e5-8b64-cd7fe886cb80.PNG)
