### PR TITLE
Sidebar Menu Navigation: Bug Fix

### DIFF
--- a/OpenVBX/views/layout/content/content_sidebar.php
+++ b/OpenVBX/views/layout/content/content_sidebar.php
@@ -61,7 +61,7 @@
 						<h3 class="vbx-nav-title"><?php echo $name ?></h3>
 						<ul class="vbx-main-nav-items">
 						<?php foreach($links as $link => $name): 
-								$class = (isset($section) && $section == $link)? 'selected vbx-nav-item' :'vbx-nav-item' ?>
+								$class = (isset($section) && $section == '/'.$link)? 'selected vbx-nav-item' :'vbx-nav-item' ?>
 								<?php if(is_array($name)): ?>
 									<?php foreach($name as $sub_id => $sub_name): ?>
 										<li class="<?php echo $class ?>">


### PR DESCRIPTION
Bug: The code only hightlights the menu as being selected if the pages are under "Messages, Setup and Admin" sections.  If the pages are from a plugin they will never get marked as being selected because the $section and the $link never match.

Fix: The easiest fix was to add a forward slash into the if statement when comparing the current section to the current link.  That was the only differece I could find and appeared to be the only reason why the code would never highlight the menu the user selected which clicking a plugin page.


![sidebar-menu-navigation-selection](https://cloud.githubusercontent.com/assets/4819310/10566532/7ab89fbe-75b7-11e5-8f12-839bdf629cec.PNG)
