### PR TITLE
Call Recording: Optionally Record Dialed Calls

### DIFF
--- a/OpenVBX/controllers/twiml.php
+++ b/OpenVBX/controllers/twiml.php
@@ -321,6 +321,7 @@ class Twiml extends MY_Controller {
 		$rest_access = $this->input->get_post('rest_access');
 		$to = $this->input->get_post('to');
 		$callerid = $this->input->get_post('callerid');
+		$record = $this->input->get_post('record');
 
 		if(!$this->session->userdata('loggedin')
 		   && !$this->login_call($rest_access))
@@ -351,6 +352,11 @@ class Twiml extends MY_Controller {
 				'callerId' => $callerid,
 				'timeout' => $this->vbx_settings->get('dial_timeout', $this->tenant->id)
 			);
+			
+			if($record !== false)
+			{
+				$options['record'] = $record;
+			}
 			
 			if (filter_var($this->input->get_post('to'), FILTER_VALIDATE_EMAIL)) 
 			{


### PR DESCRIPTION
When dialing calls the twimil controller's dial function will allow any parameters to be posted to it but it only looks for specific parameters.  I've made it optionally check the "record" parameter and if its present it will pass the value along when dialing the call.  

Functionally this gives a developer the option to record calls.  In my case I want to be able to record outbound calls and adding these feature extra lines allows me to easily record calls dialed by the user. 