### PR TITLE
Updated README, mandatory valid SSL Certificate

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,6 +4,7 @@
  * PHP 5.2.3+
  * MySQL 5+
  * Twilio Account
+ * Valid SSL Certificate if using HTTPS to access OpenVBX
 
 # Install
 


### PR DESCRIPTION
It is mandatory to utilize a valid SSL Certificate with OpenVBX and Twilio. If a certificate is expired, self-signed or otherwise Twilio will not allow the connection and the calls will be dropped immediately. 

If calls are dropped verify (https://www.twilio.com/user/account/monitor/alerts)

# Error
Twilio tried to validate your SSL certificate but was unable to find it in our certificate store.

    You are using a self signed certificate.
    The certificate authority you are using is not on our list of approved certificate authorities.
    Do not use a self signed certificate.
    Twilio uses CAs that are approved by Mozilla, you can find the full list [here]. (https://mozillacaprogram.secure.force.com/CA/IncludedCACertificateReport).

Note: OpenVBX and Twilio will work with Let's Encrypt SSL Certificate.