### PR TITLE
Always prefer the sms body from the request over the cookie

### DIFF
--- a/OpenVBX/controllers/twiml.php
+++ b/OpenVBX/controllers/twiml.php
@@ -174,7 +174,7 @@ class Twiml extends MY_Controller {
 			switch($type)
 			{
 				case 'sms':
-					if(isset($_REQUEST['Body']) && $inst_id == 'start')
+					if(isset($_REQUEST['Body']))
 					{
 						$_COOKIE['sms-body'] = $_REQUEST['Body'];
 						$sms = $_REQUEST['Body'];
@@ -185,7 +185,6 @@ class Twiml extends MY_Controller {
 					else
 					{
 						$sms = isset($_COOKIE['sms-body'])? $_COOKIE['sms-body'] : null;
-						set_cookie('sms-body', null, time()-3600);
 					}
 					$sms_data = $flow->sms_data;
 					if(!empty($sms_data))


### PR DESCRIPTION
After six months or so of testing this on my own instance, I think I'm ready to have this fixed upstream. I haven't had any issues with preferring the request body over the cookie body. 

Thoughts?

closes 
https://github.com/twilio/OpenVBX/issues/341
and perhaps
https://github.com/twilio/OpenVBX/issues/266
