### PR TITLE
Update for Twilio JS v1.4

### DIFF
--- a/OpenVBX/controllers/iframe.php
+++ b/OpenVBX/controllers/iframe.php
@@ -23,22 +23,15 @@
 
 class Iframe extends User_Controller {
 
-	protected $client_token_timeout;	
-	protected $twilio_js_version = '1.2';
+	protected $client_token_timeout;
 
 	function index() {
 		$data = $this->init_view_data();
-		
-		$twilio_js = sprintf('//static.twilio.com/libs/twiliojs/%s/twilio%s.js', 
-			$this->twilio_js_version,
-			($this->config->item('use_unminimized_js') ? '' : '.min')
-		);
-		
+        
 		$data = array_merge($data, array(
 			'site_title' => 'OpenVBX',
 			'iframe_url' => site_url('/messages'),
 			'users' => $this->get_users(),
-			'twilio_js' => $twilio_js,
 			'client_capability' => null
 		));
 		

--- a/OpenVBX/views/iframe.php
+++ b/OpenVBX/views/iframe.php
@@ -25,7 +25,8 @@
 		</iframe>
 	</div><!-- /container -->
 
-<script type="text/javascript" src="<?php echo $twilio_js; ?>"></script>
+<script type="text/javascript" src="//media.twiliocdn.com/sdk/js/client/v1.4/twilio.min.js"></script>
+
 <?php $this->load->view('js-init'); ?>
 <script type="text/javascript" src="<?php echo asset_url('assets/j/iframe.js?v='.$site_rev) ?>"></script>
 </body>

--- a/assets/j/client.js
+++ b/assets/j/client.js
@@ -87,10 +87,10 @@ var Client = {
 				Client.cancel(conn);
 			});
 			
-			Twilio.Device.presence(function(event) {
-				Client.log('event: presence');
-				Client.handleEvent(event);
-			});
+//			Twilio.Device.presence(function(event) {
+//				Client.log('event: presence');
+//				Client.handleEvent(event);
+//			});
 		
 			$('#dialer #client-ui-actions button').hide();
 		}
@@ -367,7 +367,7 @@ var Client = {
 		this.connection.accept();
 		this.status.setCallStatus(true);
 		
-		Twilio.Device.sounds.incoming(false);
+		Twilio.Device.audio.incoming(false);
 		
 		var connection_message = 'Connected';
 		if (this.connection.parameters.From) {
@@ -396,7 +396,7 @@ var Client = {
 	},
 
 	connect: function (connection) {
-		Twilio.Device.sounds.incoming(false);
+		Twilio.Device.audio.incoming(false);
 		
 		this.ui.startTick();
 		this.ui.hide_actions('button');
@@ -422,7 +422,7 @@ var Client = {
 		}
 		
 		if (connection.parameters.CallSid == this.connection.parameters.CallSid) {
-			Twilio.Device.sounds.incoming(true);
+			Twilio.Device.audio.incoming(true);
 			
 			// reset ui
 			this.ui.endTick();


### PR DESCRIPTION
Integrated Twilio JS v1.4 according to Twilio migration guide
(https://www.twilio.com/docs/api/client/twilio-client-javascript-sdk-11-12-migration-guide)

Twilio.Device.presence functionality is not currently supported in 1.4.
But that is not required to make or receive calls to and from the Twilio Client JavaScript SDK.